### PR TITLE
fix: json parse错误抛出异常

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -86,7 +86,12 @@ function handleResponseData(io) {
     if (!converter) {
       throw new Error(`no covert for ${prevType} => ${type0}`);
     }
-    responseData = converter(responseData);
+
+    try {
+      responseData = converter(responseData);
+    } catch(e) {
+      throw new Error(`converter failed from data => ${responseData}`);
+    }
 
     prevType = type0;
   }


### PR DESCRIPTION
业务开发中，此处JSON.parse抛出异常， 增加一个保护方便定位问题。